### PR TITLE
gts is depricated in gcc7, replace it with fgets

### DIFF
--- a/parser_cs2.c
+++ b/parser_cs2.c
@@ -141,7 +141,7 @@ static char *err_message[] =
         -  does service functions
 */
 
-while ( gets ( in_line ) != NULL )
+while ( fgets ( in_line,MAXLINE,stdin ) != NULL )
   {
   no_lines ++;
 


### PR DESCRIPTION
we are merging cs2 deprecated gets to fgets for gcc. Merging changes from branch cs2_gets_fix_for_gcc7 to the master.